### PR TITLE
feat: latent codec complexity profiling in cofai-eval

### DIFF
--- a/cofai/engine/run_eval.py
+++ b/cofai/engine/run_eval.py
@@ -115,8 +115,13 @@ def inference_model(
     real: bool = False,
     tasks: List[str] | None = None,
     task_specs: Any | None = None,
+    profile: bool = False,
 ) -> Tuple[Dict[str, float], Dict[str, float], Dict[str, Any]]:
-    """Single inference helper used by unified eval."""
+    """Single inference helper used by unified eval.
+
+    When ``profile`` is True, the codec-only encode/decode times recorded by the
+    model (``model._codec_time``) are merged into the returned timing dict.
+    """
 
     if tasks is None:
         tasks = []
@@ -134,14 +139,18 @@ def inference_model(
         dec_time = time.time() - t1
 
         bits_items = _bits_from_coded_data(coded_data)
-        time_items = {"enc_time": float(enc_time), "dec_time": float(dec_time)}
+        time_items = {"total_enc_time": float(enc_time), "total_dec_time": float(dec_time)}
+        if profile:
+            time_items.update(getattr(model, "_codec_time", {}) or {})
         return time_items, bits_items, task_feats
 
     t0 = time.time()
     coded_data, task_feats = model.forward_test(x, qp=qp, tasks=tasks, **codec_kw)
     elapsed = time.time() - t0
     bits_items = _bits_from_coded_data(coded_data)
-    time_items = {"enc_time": float(elapsed) / 2.0, "dec_time": float(elapsed) / 2.0}
+    time_items = {"total_enc_time": float(elapsed) / 2.0, "total_dec_time": float(elapsed) / 2.0}
+    if profile:
+        time_items.update(getattr(model, "_codec_time", {}) or {})
     return time_items, bits_items, task_feats
 
 
@@ -286,6 +295,7 @@ def eval_step(
         real=cfg.args.real,
         tasks=tasks,
         task_specs=task_specs,
+        profile=bool(cfg.args.profile),
     )
 
     missing = [t for t in tasks if t not in (task_feats or {})]
@@ -405,6 +415,59 @@ def write_eval_outputs(
     return canonical_path
 
 
+def measure_codec_complexity(
+    *, loader: Any, model: Any, device: Any, qp: Any, max_samples: int | None
+) -> Dict[str, Any]:
+    """Average latent-codec params/FLOPs over the dataset (profile pass).
+
+    Runs before the eval loop so the codec is measured on clean (non
+    inference-mode) state. ``codec_params`` is constant; the ``*_flops`` fields
+    are averaged over samples (they vary with input resolution).
+    """
+    params: Optional[int] = None
+    flops: Dict[str, List[int]] = {}
+    seen = 0
+    total = int(max_samples) if max_samples and max_samples > 0 else len(loader.dataset)
+    with tqdm(total=total, desc="Profiling", unit="sample") as pbar:
+        for batch in loader:
+            img = batch.inputs["img"].to(device, non_blocking=True)
+            comp = model.codec_complexity(img, qp=qp)
+            params = comp.get("codec_params", params)
+            for k, v in comp.items():
+                if k.endswith("_flops"):
+                    flops.setdefault(k, []).append(int(v))
+            seen += 1
+            pbar.update(1)
+            if max_samples and max_samples > 0 and seen >= max_samples:
+                break
+
+    out: Dict[str, Any] = {}
+    if params is not None:
+        out["codec_params"] = params
+    for k, vals in flops.items():
+        out[k] = sum(vals) / len(vals)
+    return out
+
+
+def _group_codec_keys(summary: Dict[str, Any]) -> Dict[str, Any]:
+    """Reorder a summary so all ``codec_*`` fields are grouped at the end."""
+    codec_order = [
+        "codec_params",
+        "codec_enc_flops",
+        "codec_dec_flops",
+        "codec_enc_time",
+        "codec_dec_time",
+    ]
+    non_codec = {k: v for k, v in summary.items() if not k.startswith("codec_")}
+    codec = {k: v for k, v in summary.items() if k.startswith("codec_")}
+    ordered: Dict[str, Any] = dict(non_codec)
+    for k in codec_order:
+        if k in codec:
+            ordered[k] = codec.pop(k)
+    ordered.update(codec)
+    return ordered
+
+
 def finalize_results(
     *, records: List[Dict[str, Any]], evaluator: MultiTaskEvaluator
 ) -> Dict[str, Any]:
@@ -477,6 +540,16 @@ def run_eval(
     ms = cfg.args.max_samples
     max_samples_i = int(ms) if ms is not None else None
 
+    complexity: Dict[str, Any] = {}
+    if bool(cfg.args.profile) and hasattr(model, "codec_complexity"):
+        complexity = measure_codec_complexity(
+            loader=loader,
+            model=model,
+            device=device,
+            qp=cfg.args.quality,
+            max_samples=max_samples_i,
+        )
+
     records = eval_loop(
         loader=loader,
         model=model,
@@ -484,7 +557,26 @@ def run_eval(
         max_samples=max_samples_i,
         ctx=step_ctx,
     )
+
     summary = finalize_results(records=records, evaluator=evaluator)
+    summary.update(complexity)
+    summary = _group_codec_keys(summary)
+
+    if "codec_params" in summary:
+        if summary["codec_params"] == 0:
+            print("[complexity] codec params: 0 (bypass)")
+        else:
+            print(f"[complexity] codec params: {summary['codec_params'] / 1e6:.2f} M")
+    bypass = summary.get("codec_params") == 0
+    for key, label in (("codec_enc_flops", "enc"), ("codec_dec_flops", "dec")):
+        if key not in summary:
+            continue
+        if summary[key] == 0 and bypass:
+            print(f"[complexity] codec {label} FLOPs: 0 (bypass)")
+        elif summary[key] == 0:
+            print(f"[complexity] codec {label} FLOPs: 0")
+        else:
+            print(f"[complexity] codec {label} FLOPs: {summary[key] / 1e9:.2f} G")
 
     run_name = str(plan_cfg.name)
     description = str(plan_cfg.description)

--- a/cofai/engine/schema.py
+++ b/cofai/engine/schema.py
@@ -143,7 +143,7 @@ def _validate_step_output_soft(step_output: StepOutput) -> None:
     timing = step_output.timing or {}
     bits = step_output.bits or {}
 
-    required_timing = {"enc_time", "dec_time"}
+    required_timing = {"total_enc_time", "total_dec_time"}
     missing = [k for k in sorted(required_timing) if k not in timing]
     if missing:
         _warn(f"missing timing keys: {missing}")
@@ -169,7 +169,7 @@ def _validate_step_output_soft(step_output: StepOutput) -> None:
         if not isinstance(r, dict):
             _warn(f"record[{i}] is not dict: {type(r)!r}")
             continue
-        for need in ("file", "quality", "enc_time", "dec_time", "bpp"):
+        for need in ("file", "quality", "total_enc_time", "total_dec_time", "bpp"):
             if need not in r:
                 _warn(f"record[{i}] missing field {need!r}")
 

--- a/cofai/models/base.py
+++ b/cofai/models/base.py
@@ -1,3 +1,5 @@
+import time
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -7,6 +9,7 @@ from compressai.models.base import CompressionModel
 from cofai.backbone import Dinov2TimmBackbone, Dinov3TimmBackbone
 from cofai.latent_codecs import BypassLatentCodec
 from cofai.engine.registry import instantiate_class, register
+from cofai.utils.complexity import latent_codec_complexity
 
 
 @register("DinoFeatureCodecModel")
@@ -147,12 +150,25 @@ class DinoFeatureCodecModel(CompressionModel):
         h_dino = self.dino.encode(x)
         return h_dino.numel()
 
+    def codec_complexity(self, x, qp=0):
+        """Latent-codec params (static) plus encode/decode FLOPs on ``x``'s tokens."""
+        with torch.no_grad():
+            h_dino = self.dino.encode(x)
+            token_res = self._token_res(x.shape[2], x.shape[3])
+        return latent_codec_complexity(self.dino_codec, h_dino, token_res, qp)
+
     def forward_test(self, x, qp=0, tasks=[], **kwargs):
         with torch.inference_mode():
             h_dino = self.dino.encode(x)
             token_res = self._token_res(x.shape[2], x.shape[3])
 
+            t0 = time.time()
             coded_unit = self.dino_codec(h_dino, token_res, qp=qp)
+            codec_t = time.time() - t0
+            self._codec_time = {
+                "codec_enc_time": codec_t / 2.0,
+                "codec_dec_time": codec_t / 2.0,
+            }
             h_dino_hat = coded_unit["h_hat"]
 
             task_feats = self._decode_tasks(h_dino_hat, token_res, tasks)
@@ -162,7 +178,9 @@ class DinoFeatureCodecModel(CompressionModel):
         h_dino = self.dino.encode(x)
         token_res = self._token_res(x.shape[2], x.shape[3])
 
+        t0 = time.time()
         coded_unit = self.dino_codec.compress(h_dino, token_res, qp=qp)
+        self._codec_time = {"codec_enc_time": time.time() - t0}
         if "pstate" not in coded_unit:
             coded_unit["pstate"] = {}
         coded_unit["pstate"]["token_res"] = token_res
@@ -170,7 +188,11 @@ class DinoFeatureCodecModel(CompressionModel):
 
     def decompress(self, coded_unit, tasks=[], **kwargs):
         token_res = coded_unit["pstate"]["token_res"]
+        t0 = time.time()
         decoded = self.dino_codec.decompress(**coded_unit)
+        codec_t = time.time() - t0
+        self._codec_time = getattr(self, "_codec_time", {})
+        self._codec_time["codec_dec_time"] = codec_t
         h_hat = decoded["h_hat"]
         return self._decode_tasks(h_hat, token_res, tasks)
 
@@ -415,6 +437,33 @@ class DinoSlideFeatureCodecModel(DinoFeatureCodecModel):
         embed_dim = int(self.dino.model.embed_dim)
         return len(crops) * hw * embed_dim
 
+    def codec_complexity(self, x, qp=0):
+        """Latent-codec params and encode/decode FLOPs over all slide crops."""
+        slide_res = self._slide_res
+        crops = self._get_slide_crops(x.shape[2], x.shape[3])
+        with torch.no_grad():
+            if self.slide_codec_mode == "stacked":
+                h = self._encode_crops_stacked(x, crops)
+                return latent_codec_complexity(self.dino_codec, h, slide_res, qp)
+            y1, x1, y2, x2 = crops[0]
+            out = latent_codec_complexity(
+                self.dino_codec,
+                self.dino.encode(x[:, :, y1:y2, x1:x2]),
+                slide_res,
+                qp,
+            )
+            for y1, x1, y2, x2 in crops[1:]:
+                comp = latent_codec_complexity(
+                    self.dino_codec,
+                    self.dino.encode(x[:, :, y1:y2, x1:x2]),
+                    slide_res,
+                    qp,
+                )
+                for key in ("codec_enc_flops", "codec_dec_flops"):
+                    if key in comp:
+                        out[key] = out.get(key, 0) + comp[key]
+        return out
+
     def _encode_crops_stacked(self, x, crops):
         """Encode every crop and stack them along the batch dim -> ``(N_crop, N, C)``.
 
@@ -436,9 +485,12 @@ class DinoSlideFeatureCodecModel(DinoFeatureCodecModel):
             slide_res = self._slide_res
             crops = self._get_slide_crops(x.shape[2], x.shape[3])
 
+            codec_t = 0.0
             if self.slide_codec_mode == "stacked":
                 h_stack = self._encode_crops_stacked(x, crops)
+                t0 = time.time()
                 out = self.dino_codec(h_stack, slide_res, qp=qp)
+                codec_t += time.time() - t0
                 seg_feats_per_crop = self._seg_feats_from_stacked_hat(
                     out["h_hat"], slide_res, len(crops)
                 )
@@ -448,12 +500,18 @@ class DinoSlideFeatureCodecModel(DinoFeatureCodecModel):
                 seg_feats_per_crop = []
                 for y1, x1, y2, x2 in crops:
                     h = self.dino.encode(x[:, :, y1:y2, x1:x2])
+                    t0 = time.time()
                     out = self.dino_codec(h, slide_res, qp=qp)
+                    codec_t += time.time() - t0
                     crop_units.append(self._crop_unit_for_bits(out))
                     seg_feats_per_crop.append(
                         self.dino.decode_seg(out["h_hat"], token_res=slide_res)
                     )
 
+            self._codec_time = {
+                "codec_enc_time": codec_t / 2.0,
+                "codec_dec_time": codec_t / 2.0,
+            }
             task_feats = self._decode_slide_tasks(
                 seg_feats_per_crop, crops, (x.shape[2], x.shape[3]), tasks
             )
@@ -465,15 +523,21 @@ class DinoSlideFeatureCodecModel(DinoFeatureCodecModel):
             slide_res = self._slide_res
             crops = self._get_slide_crops(x.shape[2], x.shape[3])
 
+            codec_t = 0.0
             if self.slide_codec_mode == "stacked":
                 h_stack = self._encode_crops_stacked(x, crops)
+                t0 = time.time()
                 crop_units = [self.dino_codec.compress(h_stack, slide_res, qp=qp)]
+                codec_t += time.time() - t0
             else:
                 crop_units = []
                 for y1, x1, y2, x2 in crops:
                     h = self.dino.encode(x[:, :, y1:y2, x1:x2])
+                    t0 = time.time()
                     crop_units.append(self.dino_codec.compress(h, slide_res, qp=qp))
+                    codec_t += time.time() - t0
 
+            self._codec_time = {"codec_enc_time": codec_t}
             return {
                 "type": "slide_crops",
                 "data": crop_units,
@@ -494,17 +558,24 @@ class DinoSlideFeatureCodecModel(DinoFeatureCodecModel):
             slide_res = tuple(pstate["slide_res"])
             mode = pstate.get("mode", self.slide_codec_mode)
 
+            codec_t = 0.0
             if mode == "stacked":
+                t0 = time.time()
                 decoded = self.dino_codec.decompress(**crop_units[0])
+                codec_t += time.time() - t0
                 seg_feats_per_crop = self._seg_feats_from_stacked_hat(
                     decoded["h_hat"], slide_res, len(crops)
                 )
             else:
                 seg_feats_per_crop = []
                 for enc in crop_units:
+                    t0 = time.time()
                     decoded = self.dino_codec.decompress(**enc)
+                    codec_t += time.time() - t0
                     seg_feats_per_crop.append(
                         self.dino.decode_seg(decoded["h_hat"], token_res=slide_res)
                     )
 
+            self._codec_time = getattr(self, "_codec_time", {})
+            self._codec_time["codec_dec_time"] = codec_t
             return self._decode_slide_tasks(seg_feats_per_crop, crops, img_hw, tasks)

--- a/cofai/utils/complexity.py
+++ b/cofai/utils/complexity.py
@@ -1,0 +1,41 @@
+"""Parameter and FLOPs measurement for latent codecs."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import torch
+from torch.utils.flop_counter import FlopCounterMode
+
+
+def count_params(module: torch.nn.Module) -> int:
+    return int(sum(p.numel() for p in module.parameters()))
+
+
+def measure_flops(module: Any, *args: Any, **kwargs: Any) -> Optional[int]:
+    """FLOPs of one ``module(*args, **kwargs)`` forward.
+
+    Returns ``None`` only when measurement raises; a successful run with zero
+    recorded ATen FLOPs (e.g. bypass pass-through) returns ``0``.
+    """
+    try:
+        flop_counter = FlopCounterMode(display=False)
+        with torch.no_grad(), flop_counter:
+            module(*args, **kwargs)
+        return int(flop_counter.get_total_flops())
+    except Exception:
+        return None
+
+
+def latent_codec_complexity(codec: torch.nn.Module, h, token_res, qp=0) -> dict[str, Any]:
+    """Params and encode/decode FLOPs for a latent codec on given tokens."""
+    out: dict[str, Any] = {"codec_params": count_params(codec)}
+    enc_flops = measure_flops(codec.compress, h, token_res, qp)
+    if enc_flops is not None:
+        out["codec_enc_flops"] = enc_flops
+    with torch.no_grad():
+        coded = codec.compress(h, token_res, qp=qp)
+    dec_flops = measure_flops(codec.decompress, **coded)
+    if dec_flops is not None:
+        out["codec_dec_flops"] = dec_flops
+    return out

--- a/examples/ctc/README-DINOv3.md
+++ b/examples/ctc/README-DINOv3.md
@@ -69,6 +69,14 @@ CUDA_VISIBLE_DEVICES=0 poetry run cofai-eval \
   conf/plan/nyuv2-val__dinov3-vitl16-slot24__Bypass__depth.yaml
 ```
 
+需要统计 **latent codec 复杂度**（参数量、编码/解码 FLOPs、codec 耗时）时，加上 `args.profile=true`；结果会写入 `result.json` 末尾的 `codec_*` 字段（`codec_params`、`codec_enc_flops`、`codec_dec_flops`、`codec_enc_time`、`codec_dec_time`）。`args.max_samples` 同样生效，不设则跑完整数据集后取平均。
+
+```bash
+CUDA_VISIBLE_DEVICES=0 poetry run cofai-eval \
+  conf/plan/ade20k-val__dinov3-vitl16-slot24__Bypass__semseg.yaml \
+  args.profile=true
+```
+
 参考结果（Bypass 不压缩，作为各任务的精度上界）：
 
 | Plan | bpp | 指标 |


### PR DESCRIPTION
## Summary

- Add `args.profile=true` to `cofai-eval` for latent codec complexity: params, encode/decode FLOPs, and codec timing in `result.json`.
- New `cofai/utils/complexity.py` (`count_params`, `measure_flops`, `latent_codec_complexity`).
- `codec_complexity()` on `DinoFeatureCodecModel` / `DinoSlideFeatureCodecModel` (slide: sum per-crop FLOPs or single stacked pass).
- Rename `enc_time`/`dec_time` → `total_enc_time`/`total_dec_time`; group `codec_*` fields at end of results.
- Profile pass runs before eval loop; respects `args.max_samples`.
- Document usage in `examples/ctc/README-DINOv3.md`.