### PR TITLE
[M2448 VTC] fix: add VBR variant VisualTokenCodecVariant for M2448 alignment

### DIFF
--- a/cofai/latent_codecs/vtc.py
+++ b/cofai/latent_codecs/vtc.py
@@ -333,3 +333,253 @@ class VisualTokenCodec(CompressionModel):
         h_hat = h_hat * self.q_scale_post[qp : qp + 1, :, :]
         h_hat = self.post_vit_blocks(h_hat)
         return {"h_hat": h_hat}
+
+
+@register_model("VisualTokenCodecVariant")
+class VisualTokenCodecVariant(CompressionModel):
+    """Variant of :class:`VisualTokenCodec` for different VBR schemas.
+    
+    VBR gains: ``q_scale_cls_enc`` / ``q_scale_cls_dec`` on the prefix
+      branch replace ``q_scale_pre`` / ``q_scale_post`` on the full sequence.
+
+    Args:
+        h_dim (int): Channel dimension of ViT features.
+        y_dim (int): Channel dimension of primary latent representation ``y``.
+        z_dim (int): Channel dimension of hyperprior latent representation ``z``.
+        groups (int or list[int]): Channel groups for channel-wise context modeling.
+        num_prefix_tokens (int): Number of prefix/register tokens in the ViT feature.
+        **kwargs (dict): Extra keyword arguments for compatibility (unused).
+    """
+
+    def __init__(
+        self,
+        h_dim=384,
+        y_dim=256,
+        z_dim=192,
+        groups=16,
+        num_prefix_tokens=1,
+        **kwargs,
+    ):
+        super().__init__()
+        if isinstance(groups, list):
+            self.groups = groups
+        elif isinstance(groups, int):
+            self.groups = [groups] * (y_dim // groups)
+        assert sum(self.groups) == y_dim, "groups must sum to y_dim"
+
+        self.y_dim = y_dim
+        self.z_dim = z_dim
+        self.num_prefix_tokens = num_prefix_tokens
+
+        # VBR learnable scales (QP in [0, 64])
+        # cls+reg token vbr
+        self.q_scale_cls_enc = nn.Parameter(torch.ones((65, h_dim, 1, 1)))
+        self.q_scale_cls_dec = nn.Parameter(torch.ones((65, h_dim, 1, 1)))
+        # patch token vbr
+        self.q_scale_enc = nn.Parameter(torch.ones((65, y_dim, 1, 1)))
+        self.q_scale_dec = nn.Parameter(torch.ones((65, y_dim, 1, 1)))
+
+        self.pre_vit_blocks = nn.Sequential(
+            *[Block(dim=h_dim, num_heads=h_dim // 64, mlp_ratio=4) for _ in range(2)]
+        )
+        self.post_vit_blocks = nn.Sequential(
+            *[Block(dim=h_dim, num_heads=h_dim // 64, mlp_ratio=4) for _ in range(2)]
+        )
+
+        self.f_a = nn.Sequential(
+            conv(h_dim, y_dim, kernel_size=3, stride=1),
+            nn.ReLU(inplace=True),
+            conv(y_dim, y_dim, kernel_size=5, stride=2),
+        )
+        self.f_s = nn.Sequential(
+            deconv(y_dim, y_dim, kernel_size=5, stride=2),
+            nn.ReLU(inplace=True),
+            deconv(y_dim, h_dim, kernel_size=3, stride=1),
+        )
+
+        h_a = nn.Sequential(
+            conv(y_dim, z_dim, kernel_size=3, stride=1),
+            nn.ReLU(inplace=True),
+            conv(z_dim, z_dim, kernel_size=5, stride=2),
+            nn.ReLU(inplace=True),
+            conv(z_dim, z_dim, kernel_size=5, stride=2),
+        )
+
+        h_s = nn.Sequential(
+            deconv(z_dim, z_dim, kernel_size=5, stride=2),
+            nn.ReLU(inplace=True),
+            deconv(z_dim, z_dim * 3 // 2, kernel_size=5, stride=2),
+            nn.ReLU(inplace=True),
+            deconv(z_dim * 3 // 2, z_dim * 2, kernel_size=3, stride=1),
+        )
+
+        channel_context = {
+            f"y{k}": nn.Sequential(
+                conv(sum(self.groups[:k]), z_dim, kernel_size=5, stride=1),
+                nn.ReLU(inplace=True),
+                conv(z_dim, z_dim, kernel_size=5, stride=1),
+                nn.ReLU(inplace=True),
+                conv(z_dim, self.groups[k] * 2, kernel_size=5, stride=1),
+            )
+            for k in range(1, len(self.groups))
+        }
+
+        spatial_context = [
+            CheckerboardMaskedConv2d(
+                self.groups[k],
+                self.groups[k] * 2,
+                kernel_size=5,
+                stride=1,
+                padding=2,
+            )
+            for k in range(len(self.groups))
+        ]
+
+        param_aggregation = [
+            sequential_channel_ramp(
+                self.groups[k] * 2 + (k > 0) * self.groups[k] * 2 + z_dim * 2,
+                self.groups[k] * 2,
+                min_ch=z_dim * 2,
+                num_layers=3,
+                interp="linear",
+                make_layer=nn.Conv2d,
+                make_act=lambda: nn.ReLU(inplace=True),
+                kernel_size=1,
+                stride=1,
+                padding=0,
+            )
+            for k in range(len(self.groups))
+        ]
+
+        scctx_latent_codec = {
+            f"y{k}": CheckerboardLatentCodec(
+                latent_codec={"y": GaussianConditionalLatentCodec(quantizer="ste")},
+                context_prediction=spatial_context[k],
+                entropy_parameters=param_aggregation[k],
+            )
+            for k in range(len(self.groups))
+        }
+
+        self.y_lc = ChannelGroupsLatentCodecContiguous(
+            groups=self.groups,
+            channel_context=channel_context,
+            latent_codec=scctx_latent_codec,
+        )
+        self.hyper_lc = HyperLatentCodec(
+            entropy_bottleneck=EntropyBottleneck(z_dim),
+            h_a=h_a,
+            h_s=h_s,
+            quantizer="ste",
+        )
+        self.cls_lc = HyperLatentCodec(
+            entropy_bottleneck=EntropyBottleneck(z_dim),
+            h_a=nn.Conv2d(h_dim, z_dim, kernel_size=1),
+            h_s=nn.Conv2d(z_dim, h_dim, kernel_size=1),
+            quantizer="ste",
+        )
+
+    def forward(self, h, token_res, qp=0, **kwargs):
+        h = self.pre_vit_blocks(h)
+
+        # cls branch with VBR scaling
+        cls_enc_gain = self.q_scale_cls_enc[qp : qp + 1, :, :, :]
+        cls_dec_gain = self.q_scale_cls_dec[qp : qp + 1, :, :, :]
+
+        h_cls = h[:, 0 : self.num_prefix_tokens]
+        h_cls = rearrange(h_cls, "B L C -> B C L 1")
+        h_cls = h_cls * cls_enc_gain
+        cls_out = self.cls_lc(h_cls)
+        h_cls_hat = rearrange(cls_out["params"] * cls_dec_gain, "B C L 1 -> B L C")
+
+        # patch branch with VBR scaling
+        enc_gain = self.q_scale_enc[qp : qp + 1, :, :, :]
+        dec_gain = self.q_scale_dec[qp : qp + 1, :, :, :]
+
+        h_patch = h[:, self.num_prefix_tokens :].contiguous()
+        h_patch = rearrange(
+            h_patch, "B (H W) C -> B C H W", H=token_res[0], W=token_res[1]
+        )
+        y = self.f_a(h_patch) * enc_gain
+        hyper_out = self.hyper_lc(y)
+        y_out = self.y_lc(y, hyper_out["params"])
+        y_hat = y_out["y_hat"] * dec_gain
+
+        h_patch_hat = self.f_s(y_hat)
+        h_patch_hat = rearrange(h_patch_hat, "B C H W -> B (H W) C")
+
+        h_hat = torch.cat([h_cls_hat, h_patch_hat], dim=1)
+        h_hat = self.post_vit_blocks(h_hat)
+
+        return {
+            "h_hat": h_hat,
+            "likelihoods": {
+                "prefix": cls_out["likelihoods"]["z"],
+                "y": y_out["likelihoods"]["y"],
+                "z": hyper_out["likelihoods"]["z"],
+            },
+        }
+
+    def compress(self, h, token_res, qp=0, **kwargs):
+        h = self.pre_vit_blocks(h)
+
+        # cls branch with VBR scaling
+        cls_enc_gain = self.q_scale_cls_enc[qp : qp + 1, :, :, :]
+
+        h_cls = h[:, 0 : self.num_prefix_tokens]
+        h_cls = rearrange(h_cls, "B L C -> B C L 1")
+        h_cls = h_cls * cls_enc_gain
+        cls_out = self.cls_lc.compress(h_cls)
+
+        # patch branch with VBR scaling
+        enc_gain = self.q_scale_enc[qp : qp + 1, :, :, :]
+
+        h_patch = h[:, self.num_prefix_tokens :].contiguous()
+        h_patch = rearrange(
+            h_patch, "B (H W) C -> B C H W", H=token_res[0], W=token_res[1]
+        )
+        y = self.f_a(h_patch) * enc_gain
+
+        y_pad = border_pad(y, 2)
+        hyper_out = self.hyper_lc.compress(y_pad)
+        _, _, y_H, y_W = y.shape
+        y_out = self.y_lc.compress(y, hyper_out["params"][:, :, :y_H, :y_W])
+
+        return {
+            "strings": {
+                "prefix": cls_out["strings"],
+                "y": y_out["strings"],
+                "z": hyper_out["strings"],
+            },
+            "pstate": {
+                "prefix_shape": cls_out["shape"],
+                "y_shape": y_out["shape"],
+                "z_shape": hyper_out["shape"],
+                "y_pad": (y_H, y_W),
+                "qp": qp,
+            },
+        }
+
+    def decompress(self, strings, pstate, **kwargs):
+        # cls branch
+        qp = pstate["qp"]
+        cls_dec_gain = self.q_scale_cls_dec[qp : qp + 1, :, :, :]
+        cls_out = self.cls_lc.decompress(strings["prefix"], pstate["prefix_shape"])
+        h_cls_hat = rearrange(cls_out["params"] * cls_dec_gain, "B C L 1 -> B L C")
+
+        # patch branch with VBR scaling
+        qp = pstate["qp"]
+        dec_gain = self.q_scale_dec[qp : qp + 1, :, :, :]
+
+        y_H, y_W = pstate["y_pad"]
+        hyper_out = self.hyper_lc.decompress(strings["z"], pstate["z_shape"])
+        y_out = self.y_lc.decompress(
+            strings["y"], pstate["y_shape"], hyper_out["params"][:, :, :y_H, :y_W]
+        )
+        y_hat = y_out["y_hat"] * dec_gain
+
+        h_patch_hat = self.f_s(y_hat)
+        h_patch_hat = rearrange(h_patch_hat, "B C H W -> B (H W) C")
+
+        h_hat = torch.cat([h_cls_hat, h_patch_hat], dim=1)
+        h_hat = self.post_vit_blocks(h_hat)
+        return {"h_hat": h_hat}

--- a/examples/vtc/plan/ade20k-val--dinov3-large-slot-1--VTC-vbr.yaml
+++ b/examples/vtc/plan/ade20k-val--dinov3-large-slot-1--VTC-vbr.yaml
@@ -48,7 +48,7 @@ model:
     pretrained: false
     ckpt_path: ${PROJECT_ROOT}/weights/dinov3/backbone/dinov3_vitl16_pretrain_lvd1689m.safetensors
   dino_codec:
-    type: cofai.latent_codecs.VisualTokenCodec
+    type: cofai.latent_codecs.vtc.VisualTokenCodecVariant
     h_dim: 1024
     y_dim: 120
     z_dim: 48

--- a/examples/vtc/plan/nyuv2-val--dinov3-large-slot-1--VTC-vbr.yaml
+++ b/examples/vtc/plan/nyuv2-val--dinov3-large-slot-1--VTC-vbr.yaml
@@ -49,7 +49,7 @@ model:
     pretrained: false
     ckpt_path: ${PROJECT_ROOT}/weights/dinov3/backbone/dinov3_vitl16_pretrain_lvd1689m.safetensors
   dino_codec:
-    type: cofai.latent_codecs.VisualTokenCodec
+    type: cofai.latent_codecs.vtc.VisualTokenCodecVariant
     h_dim: 1024
     y_dim: 120
     z_dim: 48


### PR DESCRIPTION
## Summary

- Add `VisualTokenCodecVariant` — a VBR variant of `VisualTokenCodec` where scale parameters (`q_scale_cls_enc` / `q_scale_cls_dec`) are applied on the prefix (cls+reg) branch instead of full-sequence `q_scale_pre` / `q_scale_post`, aligning with the M2448 design.
- Update ADE20K and NYUv2 VTC-VBR test configs to use `cofai.latent_codecs.vtc.VisualTokenCodecVariant`.