### PR TITLE
[M2448 VTC] feat: add DINOv3 slot24 CTC evaluation configs

### DIFF
--- a/examples/vtc/dinov3-vtc.manifest.txt
+++ b/examples/vtc/dinov3-vtc.manifest.txt
@@ -23,3 +23,4 @@ weights/dinov3/dpt_head/dinov3_vitl16_depth_nyuv2_linear_head.pth  sha256:e89316
 # --- VTC 编解码器权重 ---
 weights/VTC/dinov3-vitl16-slot-1--VTC.pth.tar  sha256:0585e23d
 weights/VTC/dinov3-vitl16-slot-1--VTC-vbr.pth.tar  sha256:e7322ae3
+weights/VTC/dinov3-vitl16-slot24--VTC-vbr.pth.tar  sha256:8cd3866b

--- a/examples/vtc/plan/ade20k-val--dinov3-large-slot24--VTC-vbr.yaml
+++ b/examples/vtc/plan/ade20k-val--dinov3-large-slot24--VTC-vbr.yaml
@@ -1,0 +1,73 @@
+# @package _global_
+defaults:
+  - /args: default
+  - /dataloader: default
+  - _self_
+
+name: ade20k-val--dinov3-large-slot24--VTC-vbr
+description: "data: ADE20K val; model: VTC + DINOv3-Large layer23 + semseg head; task: segmentation; rate: VBR"
+dataset:
+  type: SegmentationDataset
+  root: ${PROJECT_ROOT}/data/ADEChallengeData2016
+  img_path: images/validation
+  seg_map_path: annotations/validation
+  file_list: null
+  reduce_zero_label: true
+test_transforms:
+  - type: cofai.transforms.PadImage
+    size: 512
+    keys: [img, semseg]
+  - type: cofai.transforms.PadToMultiple
+    multiple: 64
+    keys: [img, semseg]
+  - type: cofai.transforms.AddIgnoreRegions
+  - type: cofai.transforms.ToTensor
+    keys: [img, semseg]
+collate:
+  mode: stack_only
+task_configs:
+  - label: semseg
+    meter:
+      type: MeanIoUMetric
+      num_classes: 150
+load:
+  path: ${PROJECT_ROOT}/weights/VTC/dinov3-vitl16-slot24--VTC-vbr.pth.tar
+  strict: false
+  rules: # type, pattern, replacement
+    - ["startswith", "dino.model", "useless"]
+model:
+  type: DinoFeatureCodecModel
+  dino_backbone:
+    type: cofai.backbone.Dinov3TimmBackbone
+    model_size: large
+    img_size: 512
+    patch_size: 16
+    dynamic_size: true
+    slot: 24
+    n_last_blocks: 1
+    pretrained: false
+    ckpt_path: ${PROJECT_ROOT}/weights/dinov3/backbone/dinov3_vitl16_pretrain_lvd1689m.safetensors
+  dino_codec:
+    type: cofai.latent_codecs.VisualTokenCodec
+    h_dim: 1024
+    y_dim: 120
+    z_dim: 48
+    groups: 24
+    num_prefix_tokens: 5
+  heads:
+    semseg:
+      type: Dinov3SegmentationHead
+      in_channels: [1024]
+      in_index: [0]
+      input_transform: resize_concat
+      channels: 1024
+      num_classes: 150
+      patch_size: 16
+      checkpoint: ${PROJECT_ROOT}/weights/dinov3/semseg_head/dinov3_vitl16_semseg_ade20k_linear_head.pth
+
+multi_run:
+  0:
+  16:
+  32:
+  48:
+  64:

--- a/examples/vtc/plan/nyuv2-val--dinov3-large-slot24--VTC-vbr.yaml
+++ b/examples/vtc/plan/nyuv2-val--dinov3-large-slot24--VTC-vbr.yaml
@@ -1,0 +1,77 @@
+# @package _global_
+defaults:
+  - /args: default
+  - /dataloader: default
+  - _self_
+
+name: nyuv2-val--dinov3-large-slot24--VTC-vbr
+description: "data: NYUv2 val; model: VTC + DINOv3-Large layer23 + depth head; task: depth estimation; rate: VBR"
+dataset:
+  type: NYUDepthDataset
+  root: ${PROJECT_ROOT}/data/NYU
+  split_file: nyu_test.txt
+test_transforms:
+  # NYU images are 480x640 (divisible by the patch size); only the image needs to
+  # become a tensor. The raw depth GT is kept as a HxW array and normalized by the
+  # meter (normalization_constant).
+  - type: cofai.transforms.PadToMultiple
+    multiple: 16
+    keys: [img]
+  - type: cofai.transforms.ToTensor
+    keys: [img]
+collate:
+  mode: stack_only
+task_configs:
+  - label: depth
+    meter:
+      type: Dinov3DepthEstimationMeter
+      names: [rmse, abs_rel, a1]
+      min_depth: 0.001
+      max_depth: 10.0
+      ignored_value: 0.0
+      eval_mask: NYU_EIGEN
+      normalization_constant: 1000.0
+load:
+  path: ${PROJECT_ROOT}/weights/VTC/dinov3-vitl16-slot24--VTC-vbr.pth.tar
+  strict: false
+  rules: # type, pattern, replacement
+    - ["startswith", "dino.model", "useless"]
+model:
+  type: DinoFeatureCodecModel
+  dino_backbone:
+    type: cofai.backbone.Dinov3TimmBackbone
+    model_size: large
+    img_size: 512
+    patch_size: 16
+    dynamic_size: true
+    slot: 24
+    n_last_blocks: 1
+    pretrained: false
+    ckpt_path: ${PROJECT_ROOT}/weights/dinov3/backbone/dinov3_vitl16_pretrain_lvd1689m.safetensors
+  dino_codec:
+    type: cofai.latent_codecs.VisualTokenCodec
+    h_dim: 1024
+    y_dim: 120
+    z_dim: 48
+    groups: 24
+    num_prefix_tokens: 5
+  heads:
+    depth:
+      type: Dinov3DepthHead
+      in_channels: [1024]
+      min_depth: 0.001
+      max_depth: 10.0
+      n_output_channels: 256
+      use_backbone_norm: true
+      use_batchnorm: true
+      use_cls_token: false
+      bins_strategy: linear
+      norm_strategy: linear
+      checkpoint: ${PROJECT_ROOT}/weights/dinov3/dpt_head/dinov3_vitl16_depth_nyuv2_linear_head.pth
+
+multi_run:
+  0:
+  16:
+  32:
+  48:
+  64:


### PR DESCRIPTION
## Summary

The existing DINOv3 VTC setup was trained for the penultimate-layer input
feature (where slot -1 is somehow missleading). DINOv3 CTC requires the final-layer feature at `slot24`.

- Add DINOv3-Large `slot24` VTC-VBR evaluation plans for ADE20K semantic
  segmentation and NYUv2 depth estimation.