### PR TITLE
[Refactor] refactor: align codec namespaces with data types (remove cofai.token_codecs)

### DIFF
--- a/cofai/index_codecs/__init__.py
+++ b/cofai/index_codecs/__init__.py
@@ -1,13 +1,15 @@
-"""Codecs for bounded discrete indices."""
+"""Codecs for discrete indices."""
 
 from .adaptive_bitmap_index import (
     AdaptiveBitmapIndexCodec,
     BoundedIndexSetBatch,
     EncodedIndexSet,
 )
+from .uniform import UniformIndexCodec
 
 __all__ = [
     "AdaptiveBitmapIndexCodec",
     "BoundedIndexSetBatch",
     "EncodedIndexSet",
+    "UniformIndexCodec",
 ]

--- a/cofai/index_codecs/uniform.py
+++ b/cofai/index_codecs/uniform.py
@@ -1,18 +1,19 @@
 import torch
 from compressai.models.base import CompressionModel
+
 from cofai.utils.coder import encode_uniform_to_bits, decode_uniform_from_bits
 
-class UniformTokenCodec(CompressionModel):
-    """Uniform token codec for compression.
-    
+
+class UniformIndexCodec(CompressionModel):
+    """Encode discrete indices under a uniform alphabet model.
+
     This codec assumes a uniform distribution over the alphabet and encodes
-    tokens using uniform quantization. It extends CompressionModel to provide
-    compression and decompression functionality for discrete tokens.
+    integer indices using the repository's uniform arithmetic-coding helpers.
     """
-    
+
     def __init__(self, alphabet_size, **kwargs):
-        """Initialize the uniform token codec.
-        
+        """Initialize the uniform index codec.
+
         Args:
             alphabet_size (int): Size of the token alphabet (number of possible values).
             **kwargs (dict): Additional keyword arguments passed to parent class.
@@ -22,10 +23,10 @@ class UniformTokenCodec(CompressionModel):
 
     def forward(self, tokens):
         """Forward pass to compute uniform likelihoods.
-        
+
         Args:
             tokens (torch.Tensor): Input tokens of any shape.
-        
+
         Returns:
             output (dict): Dictionary containing:
                 - "likelihoods" (dict): Dictionary with key "t" containing uniform
@@ -39,10 +40,10 @@ class UniformTokenCodec(CompressionModel):
 
     def _uniform_likelihood(self, tokens):
         """Compute uniform likelihoods for tokens.
-        
+
         Args:
             tokens (torch.Tensor): Input tokens of any shape.
-        
+
         Returns:
             likelihoods (torch.Tensor): Uniform likelihoods of shape matching tokens,
                 where each element is 1.0 / alphabet_size.
@@ -53,13 +54,13 @@ class UniformTokenCodec(CompressionModel):
 
     def compress(self, tokens):
         """Compress tokens to bitstring.
-        
+
         Note: tokens should not have batch dimension.
-        
+
         Args:
             tokens (torch.Tensor): Input tokens to compress. Shape should be
                 (H, W, ...) without batch dimension.
-        
+
         Returns:
             coded_unit (dict): Dictionary containing:
 
@@ -77,14 +78,14 @@ class UniformTokenCodec(CompressionModel):
 
     def decompress(self, strings, pstate, **kwargs):
         """Decompress bitstring to tokens.
-        
+
         Args:
             strings (dict): Dictionary with key "t" containing nested list with
                 encoded bitstring. Nested structure is for consistent API.
             pstate (dict): Dictionary with key "t_shape" containing the original
                 shape of tokens as a tuple.
             **kwargs (dict): Additional keyword arguments (unused).
-        
+
         Returns:
             task_feats (dict): Dictionary with key "tokens" containing decompressed
                 tokens of shape specified in pstate["t_shape"]. Note: tokens

--- a/cofai/latent_codecs/__init__.py
+++ b/cofai/latent_codecs/__init__.py
@@ -7,6 +7,7 @@ from .bypass import BypassLatentCodec
 from .vqfc import VQFeatureCodec
 from .orfc import OrthoRotationFeatureCodec
 from .raw_dtype import RawDtypeCodec
+from .fixed_gaussian import FixedGaussianCodec
 
 __all__ = [
     "FeatureScaleHyperprior",
@@ -14,6 +15,7 @@ __all__ = [
     "VQFeatureCodec",
     "OrthoRotationFeatureCodec",
     "RawDtypeCodec",
+    "FixedGaussianCodec",
     "VitUnionLatentCodec",
     "VitUnionLatentCodecWithCtx",
     "VitSeparateLatentCodec",

--- a/cofai/latent_codecs/fixed_gaussian.py
+++ b/cofai/latent_codecs/fixed_gaussian.py
@@ -4,7 +4,7 @@ import torch
 from compressai.entropy_models import GaussianConditional
 
 
-class NaiveCodec:
+class FixedGaussianCodec:
     """
     A simple "model-free" compressor for continuous features.
 
@@ -71,4 +71,3 @@ class NaiveCodec:
         total_bits = total_bytes * 8
         features_hat = self.decompress(strings, shape)
         return features_hat, total_bits
-

--- a/cofai/models/cavcodec.py
+++ b/cofai/models/cavcodec.py
@@ -3,7 +3,7 @@ import tempfile
 import torch.nn as nn
 import torch
 
-from cofai.token_codecs import NaiveCodec
+from cofai.latent_codecs import FixedGaussianCodec
 from cofai.latent_codecs.hm_sandwitch import HMCodecFFmpeg
 
 from cofai.models.cavc.sandwich_with_feature import CondTCM
@@ -40,7 +40,7 @@ class CAVCodec(nn.Module):
         self.vgg = VGGBackbone(device)
         self.mix_projector = MixFeatureProjector(prompt_dim, feature_dim, compress_feature_dim)
         self.sandwich = CondTCM(**cond_tcm)
-        self.gauss = NaiveCodec(fixed_scale)
+        self.gauss = FixedGaussianCodec(fixed_scale)
         self.ffmpeg = HMCodecFFmpeg(ffmpeg_path, ffmpeg_verbose)
         self.video_writer = VideoWriterWrapper()
         self.transform = transforms.Compose([

--- a/cofai/models/mpc.py
+++ b/cofai/models/mpc.py
@@ -5,7 +5,7 @@ from compressai.models.base import CompressionModel
 from compressai.models.utils import conv
 
 from cofai.backbone import *
-from cofai.token_codecs.base import UniformTokenCodec
+from cofai.index_codecs import UniformIndexCodec
 from cofai.latent_codecs.vit_feature_codec import (
     VitUnionLatentCodec,
     VitUnionLatentCodecWithCtx,
@@ -31,7 +31,7 @@ class MPC_I1(CompressionModel):
 
     Attributes:
         vqgan (VqganBackbone): The VQGAN backbone model.
-        vqgan_codec (UniformTokenCodec): The uniform token codec for compression.
+        vqgan_codec (UniformIndexCodec): The uniform index codec for compression.
         patch_size (int): Patch size used by the model (fixed at 16).
     """
 
@@ -432,7 +432,7 @@ class MPC_I12(CompressionModel):
         vqgan_backbone (dict): Configuration dictionary for the VQGAN backbone.
             Passed directly to VqganBackbone constructor.
         vqgan_codec (dict): Configuration dictionary for the VQGAN codec.
-            Passed directly to UniformTokenCodec constructor.
+            Passed directly to UniformIndexCodec constructor.
         dino_backbone (dict): Configuration dictionary for the DINOv2 backbone.
             Passed directly to Dinov2TimmBackbone constructor.
         dino_codec (dict): Configuration dictionary for the DINO codec.
@@ -442,7 +442,7 @@ class MPC_I12(CompressionModel):
 
     Attributes:
         vqgan (VqganBackbone): The VQGAN backbone model.
-        vqgan_codec (UniformTokenCodec): The VQGAN codec.
+        vqgan_codec (UniformIndexCodec): The VQGAN codec.
         dino (Dinov2TimmBackbone): The DINOv2 backbone model.
         dino_codec (VitUnionLatentCodecWithCtx): The DINO codec with context.
         patch_size (int): Patch size used by the DINOv2 backbone.
@@ -461,7 +461,7 @@ class MPC_I12(CompressionModel):
     ):
         super().__init__()
         self.vqgan = VqganBackbone(vqgan_backbone)
-        self.vqgan_codec = UniformTokenCodec(**vqgan_codec)
+        self.vqgan_codec = UniformIndexCodec(**vqgan_codec)
         self.dino = Dinov2TimmBackbone(**dino_backbone)
         self.dino_codec = VitUnionLatentCodecWithCtx(**dino_codec)
         self.patch_size = self.dino.patch_size
@@ -807,7 +807,7 @@ class MPC_I12_CtxAsHyper(CompressionModel):
         vqgan_backbone (dict): Configuration dictionary for the VQGAN backbone.
             Passed directly to VqganBackbone constructor.
         vqgan_codec (dict): Configuration dictionary for the VQGAN codec.
-            Passed directly to UniformTokenCodec constructor.
+            Passed directly to UniformIndexCodec constructor.
         dino_backbone (dict): Configuration dictionary for the DINOv2 backbone.
             Passed directly to Dinov2TimmBackbone constructor.
         dino_codec (dict): Configuration dictionary for the DINO codec.
@@ -817,7 +817,7 @@ class MPC_I12_CtxAsHyper(CompressionModel):
 
     Attributes:
         vqgan (VqganBackbone): The VQGAN backbone model.
-        vqgan_codec (UniformTokenCodec): The VQGAN codec.
+        vqgan_codec (UniformIndexCodec): The VQGAN codec.
         dino (Dinov2TimmBackbone): The DINOv2 backbone model.
         dino_codec (VitUnionLatentCodecCtxAsHyper): The DINO codec with context as hyperprior.
         patch_size (int): Patch size used by the DINOv2 backbone.
@@ -835,7 +835,7 @@ class MPC_I12_CtxAsHyper(CompressionModel):
     ):
         super().__init__()
         self.vqgan = VqganBackbone(vqgan_backbone)
-        self.vqgan_codec = UniformTokenCodec(**vqgan_codec)
+        self.vqgan_codec = UniformIndexCodec(**vqgan_codec)
         self.dino = Dinov2TimmBackbone(**dino_backbone)
         self.dino_codec = VitUnionLatentCodecCtxAsHyper(**dino_codec)
         self.patch_size = self.dino.patch_size

--- a/cofai/token_codecs/__init__.py
+++ b/cofai/token_codecs/__init__.py
@@ -1,7 +1,0 @@
-from .base import UniformTokenCodec
-from .naive_codec import NaiveCodec
-
-__all__ = [
-    "UniformTokenCodec",
-    "NaiveCodec",
-]

--- a/docs/api/token_codecs.md
+++ b/docs/api/token_codecs.md
@@ -1,1 +1,0 @@
-::: cofai.token_codecs

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,6 @@ CoFAI currently provides:
 - [cofai.backbone](./api/backbone.md)
 - [cofai.latent_codecs](./api/latent_codecs.md)
 - [cofai.index_codecs](./api/index_codecs.md)
-- [cofai.token_codecs](./api/token_codecs.md)
 - [cofai.layers](./api/layers.md)
 - [cofai.datasets](./api/datasets.md)
 - [cofai.losses](./api/losses.md)

--- a/examples/mpc/config/eval_MPC12-v2-small.yaml
+++ b/examples/mpc/config/eval_MPC12-v2-small.yaml
@@ -36,7 +36,7 @@ model:
       dropout: 0.0
 
   vqgan_codec:
-    type: UniformTokenCodec
+    type: cofai.index_codecs.UniformIndexCodec
     alphabet_size: 1024
 
   dino_backbone:

--- a/examples/mpc/train_config/MPC12-v3-large-extract.yaml
+++ b/examples/mpc/train_config/MPC12-v3-large-extract.yaml
@@ -56,7 +56,7 @@ model:
       dropout: 0.0
 
   vqgan_codec:
-    type: UniformTokenCodec
+    type: cofai.index_codecs.UniformIndexCodec
     alphabet_size: 1024
 
   dino_backbone:

--- a/examples/mpc/train_config/MPC12-v3-large-offline.yaml
+++ b/examples/mpc/train_config/MPC12-v3-large-offline.yaml
@@ -25,7 +25,7 @@ model:
       dropout: 0.0
 
   vqgan_codec:
-    type: UniformTokenCodec
+    type: cofai.index_codecs.UniformIndexCodec
     alphabet_size: 1024
 
   dino_backbone:

--- a/tests/test_index_codecs.py
+++ b/tests/test_index_codecs.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import torch
+
+from cofai.engine.registry import instantiate_class
+from cofai.index_codecs import UniformIndexCodec
+from cofai.latent_codecs import FixedGaussianCodec
+
+
+def test_uniform_index_codec_reports_uniform_likelihoods():
+    indices = torch.tensor([[0, 1], [2, 3]])
+    codec = UniformIndexCodec(alphabet_size=4)
+
+    output = codec(indices)
+
+    assert output["tokens"] is indices
+    torch.testing.assert_close(
+        output["likelihoods"]["t"],
+        torch.full(indices.shape, 0.25),
+    )
+
+
+def test_uniform_index_codec_can_be_built_from_qualified_config():
+    codec = instantiate_class(
+        {
+            "type": "cofai.index_codecs.UniformIndexCodec",
+            "alphabet_size": 8,
+        }
+    )
+
+    assert isinstance(codec, UniformIndexCodec)
+
+
+def test_fixed_gaussian_codec_lives_in_latent_codec_namespace():
+    assert FixedGaussianCodec.__module__ == "cofai.latent_codecs.fixed_gaussian"

--- a/zensical.toml
+++ b/zensical.toml
@@ -13,7 +13,6 @@ nav = [
     "api/backbone.md",
     "api/latent_codecs.md",
     "api/index_codecs.md",
-    "api/token_codecs.md",
     "api/heads.md",
     "api/layers.md",
     "api/datasets.md",


### PR DESCRIPTION
## Summary

- Move the discrete `UniformTokenCodec` implementation to `cofai.index_codecs` as `UniformIndexCodec`.
- Move the continuous fixed-Gaussian `NaiveCodec` implementation to `cofai.latent_codecs` as `FixedGaussianCodec`.
- Update MPC/CAV imports, MPC configuration files, public exports, and API navigation.
- Remove the legacy `cofai.token_codecs` package and its documentation entry.

## Why

The legacy `token_codecs` namespace mixed two different data domains. VQ/VQGAN outputs are bounded discrete indices and belong under `index_codecs`, while the fixed-Gaussian implementation operates on continuous feature tensors and belongs under `latent_codecs`. This change makes the package boundaries reflect the encoded data type.

## Developer impact

Repository callers and configurations have been migrated to the new fully-qualified names:

- `cofai.index_codecs.UniformIndexCodec`
- `cofai.latent_codecs.FixedGaussianCodec`

The old `cofai.token_codecs` imports are intentionally removed.

## Validation

- `pytest -q`: 63 passed
- Ruff checks passed for the new and relocated codec modules
- Import smoke checks passed for the MPC and CAV model callers
